### PR TITLE
Differentiate the user, admin sidebars

### DIFF
--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -1,23 +1,51 @@
 import "./sidebar.scss";
 import DashboardIcon from "@mui/icons-material/Dashboard";
 import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
-import LocalShippingIcon from "@mui/icons-material/LocalShipping";
-import CreditCardIcon from "@mui/icons-material/CreditCard";
-import StoreIcon from "@mui/icons-material/Store";
+// import LocalShippingIcon from "@mui/icons-material/LocalShipping";
+// import CreditCardIcon from "@mui/icons-material/CreditCard";
+// import StoreIcon from "@mui/icons-material/Store";
+import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import InsertChartIcon from "@mui/icons-material/InsertChart";
-import SettingsApplicationsIcon from "@mui/icons-material/SettingsApplications";
+// import SettingsApplicationsIcon from "@mui/icons-material/SettingsApplications";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import SettingsSystemDaydreamOutlinedIcon from "@mui/icons-material/SettingsSystemDaydreamOutlined";
-import PsychologyOutlinedIcon from "@mui/icons-material/PsychologyOutlined";
+// import PsychologyOutlinedIcon from "@mui/icons-material/PsychologyOutlined";
 import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined";
+import SupportAgentIcon from "@mui/icons-material/SupportAgent";
 // import {DashboardIcon, PersonOutlineIcon} from "@mui/icons-material"; // -> Upper can be abbreviated
 import { Link, useNavigate } from "react-router-dom";
 import { DarkModeContext } from "../../context/darkModeContext";
 import { AuthContext } from "../../context/AuthContext";
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
+
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../../firebase";
 
 const Sidebar = () => {
+  // Run only once when the component is build
+  useEffect(() => {
+    const fetchUserType = async () => {
+      try {
+        const user = JSON.parse(localStorage.getItem("user")); // Getting a user from local storage
+        const docSnap = await getDoc(doc(db, "users", user.uid)); // uid is the document id of "users"
+
+        if (docSnap.exists()) {
+          {
+            docSnap.data().type === "admin" ? setAdmin(true) : setAdmin(false);
+          }
+        } else {
+          // docSnap.data() will be undefined in this case
+          console.log("No such document!");
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    };
+    fetchUserType();
+  }, []);
+
+  const [admin, setAdmin] = useState();
   const { dispatchDarkMode } = useContext(DarkModeContext);
   const { dispatch } = useContext(AuthContext);
 
@@ -44,12 +72,14 @@ const Sidebar = () => {
             <span>Dashboard</span>
           </li>
           <p className="title">LISTS</p>
-          <li>
-            <Link to="/users" style={{ textDecoration: "none" }}>
-              <PersonOutlineIcon className="icon" />
-              <span>Users</span>
-            </Link>
-          </li>
+          {admin && (
+            <li>
+              <Link to="/users" style={{ textDecoration: "none" }}>
+                <PersonOutlineIcon className="icon" />
+                <span>Users</span>
+              </Link>
+            </li>
+          )}
           {/* <li>
             <Link to="/products" style={{ textDecoration: "none" }}>
               <StoreIcon className="icon" />
@@ -58,19 +88,19 @@ const Sidebar = () => {
           </li> */}
           <li>
             <Link to="/files" style={{ textDecoration: "none" }}>
-              <StoreIcon className="icon" />
+              <InsertDriveFileIcon className="icon" />
               <span>Files</span>
             </Link>
           </li>
-          <li>
+          {/* <li>
             <CreditCardIcon className="icon" />
             <span>Orders</span>
           </li>
           <li>
             <LocalShippingIcon className="icon" />
             <span>Delivery</span>
-          </li>
-          <p className="title">USEFUL</p>
+          </li> */}
+          {/* <p className="title">USEFUL</p>
           <li>
             <InsertChartIcon className="icon" />
             <span>Stats</span>
@@ -78,20 +108,36 @@ const Sidebar = () => {
           <li>
             <NotificationsNoneIcon className="icon" />
             <span>Notifications</span>
-          </li>
+          </li> */}
           <p className="title">SERVICE</p>
+          {admin && (
+            <li>
+              <InsertChartIcon className="icon" />
+              <span>Statistics</span>
+            </li>
+          )}
+          {admin && (
+            <li>
+              <SettingsSystemDaydreamOutlinedIcon className="icon" />
+              <span>System Health</span>
+            </li>
+          )}
           <li>
-            <SettingsSystemDaydreamOutlinedIcon className="icon" />
-            <span>System Health</span>
+            <NotificationsNoneIcon className="icon" />
+            <span>Notifications</span>
           </li>
           <li>
+            <SupportAgentIcon className="icon" />
+            <span>Enqueries</span>
+          </li>
+          {/* <li>
             <PsychologyOutlinedIcon className="icon" />
             <span>Logs</span>
           </li>
           <li>
             <SettingsApplicationsIcon className="icon" />
             <span>Settings</span>
-          </li>
+          </li> */}
           <p className="title">USER</p>
           <li>
             <AccountCircleOutlinedIcon className="icon" />

--- a/src/pages/otp/OTP.jsx
+++ b/src/pages/otp/OTP.jsx
@@ -89,6 +89,7 @@ const OTP = () => {
         setDoc(doc(db, "users", user.uid), {
           phoneNumber: user.phoneNumber,
           status: "activated",
+          type: "user",
           timeStamp: serverTimestamp(),
         });
 

--- a/src/pages/register/Register.jsx
+++ b/src/pages/register/Register.jsx
@@ -121,6 +121,7 @@ const Register = () => {
         email: email,
         username: username,
         status: "activated",
+        type: "user",
         timeStamp: serverTimestamp(),
       });
 


### PR DESCRIPTION
- Changed Sidebar.jsx 
1. useEffect will get the type of user from “users” Firestore database
2. admin will be set to true of the type of “users” doc is “admin”
3. Some of the tabs inside a Sidebar.jsx - {admin && li tags for [certain tabs]}
4. admin = true will show tabs above 

- On register or OTP login, the user will have type=”user” as a default

- Files changed: Sidebar.jsx
Register.jsx (type: "user")
OTP.jsx (type: "user")